### PR TITLE
Fix top.gg mistype

### DIFF
--- a/asyncdagpi/http.py
+++ b/asyncdagpi/http.py
@@ -26,7 +26,7 @@ class HTTP:
     """
     HTTP Client
     -----------
-    Represents an HTTP client sending HTTP requests to the top.gg API.
+    Represents an HTTP client sending HTTP requests to the dagpi API.
         .. _aiohttp session:
 https://aiohttp.readthedocs.io/en/stable/client_reference.html#client-session
         Parameters


### PR DESCRIPTION
Noticed a mistype of 'top.gg' in the HTTP client docstring rather than dagpi.